### PR TITLE
Run install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -47,4 +47,5 @@ mkdir ~/dev
 cd ~/dev
 git clone ssh://git@github.com/HeavyWater-Solutions/hw-cli.git
 
+cd ~
 ./dev/hw-cli/process/laptop-install.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -47,4 +47,4 @@ mkdir ~/dev
 cd ~/dev
 git clone ssh://git@github.com/HeavyWater-Solutions/hw-cli.git
 
-printf "\n\n\nRun the following command:\n\n\t./dev/hw-cli/process/laptop-install.sh\n"
+./dev/hw-cli/process/laptop-install.sh


### PR DESCRIPTION
any reason we shouldn't just trigger the laptop-install shell script instead of telling the user to, make the entire process one step?